### PR TITLE
Adding a shell.nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
-
+resolver = "2"
 members = [
     "trawld",
     "trawldb",
     "trawlcat",
 ]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,7 @@
 [workspace]
-resolver = "2"
+
 members = [
     "trawld",
     "trawldb",
     "trawlcat",
 ]
-

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-23.11";
+  pkgs = import nixpkgs { config = {}; overlays = []; };
+in
+
+pkgs.mkShellNoCC {
+  packages = with pkgs; [
+    gnumake
+    cargo
+    rustc
+    gcc
+    clang
+  ];
+}


### PR DESCRIPTION
A [shell.nix file ](https://nix.dev/tutorials/first-steps/declarative-shell#a-basic-shell-nix-file) help to create a Ad hoc shell environments with the mentioned dependencies without permanently installing them. 

With Nix installed `nix-shell` command will make the required shell environment.
