### PR TITLE
Migrate to clap 4

### DIFF
--- a/trawlcat/Cargo.toml
+++ b/trawlcat/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/regolith-linux/trawl"
 
 [dependencies]
 trawldb = "0.2.9"
-clap = { version = "3.2.8", features = ["derive"] }
+clap = { version = "4.5.24", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0.86"

--- a/trawlcat/src/main.rs
+++ b/trawlcat/src/main.rs
@@ -1,9 +1,9 @@
 use std::error::Error;
-use clap::{Parser, AppSettings};
+use clap::Parser;
 use trawlcat::rescat;
 
 #[derive(Parser)]
-#[clap(author, version, about, setting(AppSettings::ArgRequiredElseHelp))]
+#[clap(author, version, about, arg_required_else_help=true)]
 struct Args {
 
     /// resource name

--- a/trawld/Cargo.toml
+++ b/trawld/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/regolith-linux/trawl"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.8", features = ["derive"] }
+clap = { version = "4.5.24", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 colored = "2.0.0"

--- a/trawldb/Cargo.toml
+++ b/trawldb/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/regolith-linux/trawl"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.8", features = ["derive"] }
+clap = { version = "4.5.24", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 

--- a/trawldb/src/parser.rs
+++ b/trawldb/src/parser.rs
@@ -1,7 +1,7 @@
-use clap::{AppSettings, Parser};
+use clap::Parser;
 
 #[derive(Parser, Debug, Clone, PartialEq, Eq)]
-#[clap(author, version, about, setting(AppSettings::ArgRequiredElseHelp))]
+#[clap(author, version, about, arg_required_else_help=true)]
 /// Config Manager Client for trawld
 pub struct CliArgs {
     /// load resources from file
@@ -53,8 +53,7 @@ pub struct CliArgs {
         short,
         long,
         value_parser,
-        min_values = 0,
-        max_values = 1,
+        num_args(0..=1),
         value_name = "string"
     )]
     pub query: Option<Vec<String>>,


### PR DESCRIPTION
# Migrated to clap 4
issue #4 

## changes
- Replaced Deprecated `AppSettings::ArgRequiredElseHelp` with `arg_required_with_help=true`
- Replaced Deprecated `min_value` and `max_value` with `num_args(0..=1) `

reference: clap 4 change [log](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28)