### PR TITLE
fix: fix target to remove cycle present in ubuntu 26.04 gdm3.  Fixes …

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+trawl (0.2.6) jammy; urgency=medium
+
+  * fix: fix target to remove cycle present in ubuntu 26.04 gdm3.  Fixes gdm3 breaking when regolith is installed
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sat, 25 Apr 2026 13:32:01 -0700
+
 trawl (0.2.5-1) focal; urgency=medium
 
   [ Manthan Patil ]

--- a/trawld/trawld.service
+++ b/trawld/trawld.service
@@ -12,4 +12,4 @@ Type=dbus
 BusName=org.regolith.Trawl
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
…gdm3 breaking when regolith is installed

RCA'd with claude.

Verified fix on local install by manually editing files and seeing that gdm3 screen loads upon reboot. Before fix gdm3 does not load.


```
Summary: Regolith Sway session units break GDM3 greeter on Ubuntu 26.04
Installing regolith-session-sway prevents the GDM3 greeter from displaying. GDM retries the greeter 7 times then gives up, leaving the user at a text-mode cursor.
Root cause: Two services — sway-audio-idle-inhibit.service and trawld.service — ship with WantedBy=default.target in their [Install] sections. This causes graphical-session.target to be activated during the GDM greeter user's systemd startup (before gnome-shell has launched), because these services depend on it for ordering. When gnome-session then runs, it sees graphical-session.target already active, logs "A graphical session is already running!", and exits. No GNOME Shell starts, GDM's display never gets a session registration, and the greeter fails.
Additionally, foot-server.socket (pulled in as a dependency of foot) uses WantedBy=sockets.target combined with After=graphical-session.target, which creates a dependency cycle that compounds the same problem.
Fix: All three units should use WantedBy=graphical-session.target (not default.target or sockets.target). This ensures they only activate when a compositor has started a graphical session, and keeps them out of the GDM greeter's startup path. For foot-server.socket, which is owned by the foot package, the fix should be shipped as a drop-in override or handled via postinst symlink management in regolith-session-sway.
```